### PR TITLE
Silence New Moth Creature

### DIFF
--- a/patches/0-sounds.yaml
+++ b/patches/0-sounds.yaml
@@ -110,3 +110,11 @@ CreatureSoundData.dbc: #re-enabled, he's too goddamn annoying
     values:
       LoopSoundID: 0
 #####################################
+
+### Moth Buzzing ###################
+SoundEntries.dbc:
+  - type: update
+    key: 4594 # SilithidWaspLoop
+    values:
+      VolumeFloat: 0.0
+#####################################


### PR DESCRIPTION
With the recent addition of the new Moth creature, I couldn't notice the constant buzzing coming from it, it gets even worse when a Hunter has it as a pet. After long investigation, turned out that it's constant buzzing sound is taken from `Silithid Wasp`.

I would be glad if you could integrate this change (silencing this sound) into **Patch-O**, but I understand if you think that it's not annoying enough to be silenced. 

Here's how it sounds:
[SilithidWingLoop2.wav](https://github.com/user-attachments/files/26367107/SilithidWingLoop2.wav)

Thank you for your work!
